### PR TITLE
Stops ACDC from triggering the Dice Config Menu when typing in text fields.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## v1.0.2
+- Stops ACDC from triggering the Dice Config Menu when typing in text fields.
+
 ## v1.0.1
 - Adds per dice manual toggles
   - Shift + Left Click on the ACDC button will open the Foundry Dice Configuration Menu and ACDC will then toggle only the user specified dice for manual rolling.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "acdc",
     "title": "Alter Core Dice Configuration",
     "description": "A small module to set Foundry core dice configuration",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "authors": [
         {
             "name": "thatlonelybugbear",
@@ -35,6 +35,6 @@
     "url": "https://github.com/thatlonelybugbear/acdc",
     "license": "https://raw.githubusercontent.com/thatlonelybugbear/acdc/main/LICENSE",
     "manifest": "https://github.com/thatlonelybugbear/acdc/releases/latest/download/module.json",
-    "download": "https://github.com/thatlonelybugbear/acdc/releases/download/v1.0.1/module.zip",
+    "download": "https://github.com/thatlonelybugbear/acdc/releases/download/v1.0.2/module.zip",
     "changelog": "https://raw.githubusercontent.com/thatlonelybugbear/acdc/main/Changelog.md"
 }

--- a/module/acdc-main.mjs
+++ b/module/acdc-main.mjs
@@ -121,7 +121,18 @@ Hooks.once('init', () => {
 
 Hooks.on('ready', () => {
 	document.addEventListener('keydown', (event) => {
-		if ((event.ctrlKey || event.shiftKey) && game.keybindings.get('acdc', 'keybind').some((k) => k.key === event.code)) acdcMenu();
+		const active = document.activeElement;
+		const isTyping = active && (
+			active.tagName === 'INPUT' ||
+			active.tagName === 'TEXTAREA' ||
+			active.isContentEditable
+		);
+	
+		if (isTyping) return;
+	
+		// Trigger keybind logic if not typing
+		if ((event.ctrlKey || event.shiftKey) && game.keybindings.get('acdc', 'keybind').some((k) => k.key === event.code)) {
+			acdcMenu();
+		}
 	});
 });
-


### PR DESCRIPTION
Closes #13 