### PR TITLE
Support CTRL+B while focusing a text field

### DIFF
--- a/module/acdc-main.mjs
+++ b/module/acdc-main.mjs
@@ -151,12 +151,17 @@ Hooks.once('init', () => {
 Hooks.on('ready', () => {
 	document.addEventListener('keydown', (event) => {
 		const active = document.activeElement;
-		const isTyping = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable);
+		const isTypingPlain = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA');
+		const isTypingEditor = active && active.isContentEditable;
 
-		if (isTyping) return;
+		// We only support the shortcut with modifiers.
+		if (!event.ctrlKey && !event.shiftKey) return;
+		// The WYSIWYG editor uses CTRL+B to toggle bold --> no shortcut in there.
+		if (isTypingEditor) return;
+		// In the normal editor we ignore SHIFT+B because writing a literal B is something people want to do....
+		if (isTypingPlain && event.shiftKey) return;
 
-		// Trigger keybind logic if not typing
-		if ((event.ctrlKey || event.shiftKey) && game.keybindings.get('acdc', 'keybind').some((k) => k.key === event.code)) {
+		if (game.keybindings.get('acdc', 'keybind').some((k) => k.key === event.code)) {
 			event.preventDefault();
 			acdcMenu();
 		}


### PR DESCRIPTION
I noticed that while focusing the text field, the ^B shortcut still triggered the browser's bookmark sidebar instead of toggling dice modes.

With this change the typing check is only applied to SHIFT+B (where it's useful so people can type `B`), but not to CTRL+B which has no special meaning when just writing text anyway.